### PR TITLE
Fix Vercel deployment by updating build configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,14 @@
 {
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist"
-      }
-    }
-  ]
+	"builds": [
+		{
+			"src": "__create/index.ts",
+			"use": "@vercel/node"
+		}
+	],
+	"routes": [
+		{
+			"src": "/(.*)",
+			"dest": "__create/index.ts"
+		}
+	]
 }


### PR DESCRIPTION
The Vercel deployment was failing because it was configured to use `@vercel/static-build`, which expects a `dist` directory. However, this is a server-rendered application that builds to a `build` directory and requires a Node.js environment.

I have updated the `vercel.json` file to use the `@vercel/node` builder and pointed it to the correct server entry point. This aligns the deployment configuration with the project's architecture and should resolve the deployment error.